### PR TITLE
change tab-completion style to show all candidates like bash

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,4 +1,4 @@
-# Initialisations
+﻿# Initialisations
 oh-my-posh --init --shell pwsh --config C:\Users\it\OneDrive\ohmyposh.json | Invoke-Expression
 
 # Module imports
@@ -17,3 +17,6 @@ if (Test-Path ~\OneDrive\Documents\PowerShell\LocalModules)
   }
 
 }
+
+# Change tab-completion behaviour to be more bash-like
+Set-PSReadLineKeyHandler -Key Tab -Function Complete


### PR DESCRIPTION
Hi,

this setting is a matter of preference so feel free to not merge if it's not for you - it's something I use though and wanted to share.

When starting a cmdlet or parameter name and tab-completing, this setting will display all possible completions instead of cycling through them one-by-one like by default:

```powershell
~/Nextcloud
❯ Get-ChildItem -F # pressing Tab, Tab
Filter         Force          FollowSymlink  File

~/Nextcloud
❯ Get-ChildItem -F
```

There is an additional, invisible diff on line 1 because I saved the script with UTF8-with-BOM encoding instead of raw UTF8. This doesn't make a difference now, but Windows PowerShell requires the BOM encoding to understand non-ASCII characters, so if you ever want to add umlauts or unicode-characters to your profile file for any reason, PowerShell would now pick them up correctly.

Btw, I noticed you spelled "Initialisations" with an "s" so I hope "behaviour" is also the appropriate spelling of that word for your locality 😃